### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,8 +303,11 @@ install(FILES
 
 
 #Add an alias so that library can be used inside the build tree, e.g. when testing
-add_library(${PROJECT_NAME}::${PROJECT_LIB_SHARED} ALIAS ${PROJECT_LIB_SHARED})
-add_library(${PROJECT_NAME}::${PROJECT_LIB_STATIC} ALIAS ${PROJECT_LIB_STATIC})
+if(MODEST_BUILD_SHARED)
+   add_library(${PROJECT_NAME}::${PROJECT_LIB_SHARED} ALIAS ${PROJECT_LIB_SHARED})
+elseif(MODEST_BUILD_STATIC)
+   add_library(${PROJECT_NAME}::${PROJECT_LIB_STATIC} ALIAS ${PROJECT_LIB_STATIC})
+endif()
 
 
 ################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,8 @@ install(FILES
 #Add an alias so that library can be used inside the build tree, e.g. when testing
 if(MODEST_BUILD_SHARED)
    add_library(${PROJECT_NAME}::${PROJECT_LIB_SHARED} ALIAS ${PROJECT_LIB_SHARED})
-elseif(MODEST_BUILD_STATIC)
+endif()
+if(MODEST_BUILD_STATIC)
    add_library(${PROJECT_NAME}::${PROJECT_LIB_STATIC} ALIAS ${PROJECT_LIB_STATIC})
 endif()
 


### PR DESCRIPTION
Without this CMake failes when setting `-DMODEST_BUILD_SHARED=OFF` or `-DMODEST_BUILD_STATIC=OFF`.