### PR TITLE
Add collation for border radius; 

### DIFF
--- a/include/modest/style/map.h
+++ b/include/modest/style/map.h
@@ -47,6 +47,7 @@ void modest_style_map_collate_declaration_border_top(modest_t* modest, myhtml_tr
 void modest_style_map_collate_declaration_border_bottom(modest_t* modest, myhtml_tree_node_t* node, mycss_declaration_entry_t* decl, mycss_property_type_t type, modest_style_raw_specificity_t* spec);
 void modest_style_map_collate_declaration_border_left(modest_t* modest, myhtml_tree_node_t* node, mycss_declaration_entry_t* decl, mycss_property_type_t type, modest_style_raw_specificity_t* spec);
 void modest_style_map_collate_declaration_border_right(modest_t* modest, myhtml_tree_node_t* node, mycss_declaration_entry_t* decl, mycss_property_type_t type, modest_style_raw_specificity_t* spec);
+void modest_style_map_collate_declaration_border_radius(modest_t* modest, myhtml_tree_node_t* node, mycss_declaration_entry_t* decl, mycss_property_type_t type, modest_style_raw_specificity_t* spec);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/modest/style/map_resource.h
+++ b/include/modest/style/map_resource.h
@@ -85,7 +85,7 @@ static const modest_style_map_collate_f modest_style_map_static_collate_declarat
     modest_style_map_collate_declaration_for_all,
     modest_style_map_collate_declaration_for_all,
     modest_style_map_collate_declaration_for_all,
-    modest_style_map_collate_declaration_for_all,
+    modest_style_map_collate_declaration_border_radius,
     modest_style_map_collate_declaration_border_right,
     modest_style_map_collate_declaration_for_all,
     modest_style_map_collate_declaration_for_all,

--- a/source/modest/style/map.c
+++ b/source/modest/style/map.c
@@ -344,3 +344,36 @@ void modest_style_map_collate_declaration_border_right(modest_t* modest, myhtml_
     }
 }
 
+/* border radius */
+void modest_style_map_collate_declaration_border_radius(modest_t* modest, myhtml_tree_node_t* node, mycss_declaration_entry_t* decl, mycss_property_type_t type, modest_style_raw_specificity_t* spec)
+{
+    if(node->data == NULL || decl->value == NULL)
+        return;
+
+    mycss_values_shorthand_four_t *val_four = (mycss_values_shorthand_four_t*)decl->value;
+
+    if(val_four->two == NULL) {
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->one, MyCSS_PROPERTY_TYPE_BORDER_TOP_LEFT_RADIUS, spec);
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->one, MyCSS_PROPERTY_TYPE_BORDER_TOP_RIGHT_RADIUS, spec);
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->one, MyCSS_PROPERTY_TYPE_BORDER_BOTTOM_RIGHT_RADIUS, spec);
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->one, MyCSS_PROPERTY_TYPE_BORDER_BOTTOM_LEFT_RADIUS, spec);
+    }
+    else if(val_four->three == NULL) {
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->one, MyCSS_PROPERTY_TYPE_BORDER_TOP_LEFT_RADIUS, spec);
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->two, MyCSS_PROPERTY_TYPE_BORDER_TOP_RIGHT_RADIUS, spec);
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->one, MyCSS_PROPERTY_TYPE_BORDER_BOTTOM_RIGHT_RADIUS, spec);
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->two, MyCSS_PROPERTY_TYPE_BORDER_BOTTOM_LEFT_RADIUS, spec);
+    }
+    else if(val_four->four == NULL) {
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->one, MyCSS_PROPERTY_TYPE_BORDER_TOP_LEFT_RADIUS, spec);
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->two, MyCSS_PROPERTY_TYPE_BORDER_TOP_RIGHT_RADIUS, spec);
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->three, MyCSS_PROPERTY_TYPE_BORDER_BOTTOM_RIGHT_RADIUS, spec);
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->two, MyCSS_PROPERTY_TYPE_BORDER_BOTTOM_LEFT_RADIUS, spec);
+    }
+    else {
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->one, MyCSS_PROPERTY_TYPE_BORDER_TOP_LEFT_RADIUS, spec);
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->two, MyCSS_PROPERTY_TYPE_BORDER_TOP_RIGHT_RADIUS, spec);
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->three, MyCSS_PROPERTY_TYPE_BORDER_BOTTOM_RIGHT_RADIUS, spec);
+        modest_style_map_collate_declaration_for_all(modest, node, val_four->four, MyCSS_PROPERTY_TYPE_BORDER_BOTTOM_LEFT_RADIUS, spec);
+    }
+}

--- a/source/modest/style/map.h
+++ b/source/modest/style/map.h
@@ -47,6 +47,7 @@ void modest_style_map_collate_declaration_border_top(modest_t* modest, myhtml_tr
 void modest_style_map_collate_declaration_border_bottom(modest_t* modest, myhtml_tree_node_t* node, mycss_declaration_entry_t* decl, mycss_property_type_t type, modest_style_raw_specificity_t* spec);
 void modest_style_map_collate_declaration_border_left(modest_t* modest, myhtml_tree_node_t* node, mycss_declaration_entry_t* decl, mycss_property_type_t type, modest_style_raw_specificity_t* spec);
 void modest_style_map_collate_declaration_border_right(modest_t* modest, myhtml_tree_node_t* node, mycss_declaration_entry_t* decl, mycss_property_type_t type, modest_style_raw_specificity_t* spec);
+void modest_style_map_collate_declaration_border_radius(modest_t* modest, myhtml_tree_node_t* node, mycss_declaration_entry_t* decl, mycss_property_type_t type, modest_style_raw_specificity_t* spec);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/source/modest/style/map_resource.h
+++ b/source/modest/style/map_resource.h
@@ -85,7 +85,7 @@ static const modest_style_map_collate_f modest_style_map_static_collate_declarat
     modest_style_map_collate_declaration_for_all,
     modest_style_map_collate_declaration_for_all,
     modest_style_map_collate_declaration_for_all,
-    modest_style_map_collate_declaration_for_all,
+    modest_style_map_collate_declaration_border_radius,
     modest_style_map_collate_declaration_border_right,
     modest_style_map_collate_declaration_for_all,
     modest_style_map_collate_declaration_for_all,

--- a/source/mycss/property/parser.c
+++ b/source/mycss/property/parser.c
@@ -896,6 +896,51 @@ bool mycss_property_parser_border_radius_two(mycss_entry_t* entry, mycss_token_t
     mycss_values_shorthand_four_t *value = dec_entry->value;
     
     if(mycss_property_shared_check_declaration_end(entry, token)) {
+        mycss_values_shorthand_two_type_t* top_right = ((mycss_values_shorthand_two_type_t*) (value->two->value));
+        if (top_right != NULL)
+        {
+            if (top_right->one == NULL)
+            {
+                top_right->one = ((mycss_values_shorthand_two_type_t*) (value->one->value))->one;
+                top_right->type_one = ((mycss_values_shorthand_two_type_t*) (value->one->value))->type_one;
+            }
+            else if (top_right->two == NULL)
+            {
+                top_right->two = ((mycss_values_shorthand_two_type_t*) (value->one->value))->two;
+                top_right->type_two = ((mycss_values_shorthand_two_type_t*) (value->one->value))->type_two;
+            }
+        }
+
+        mycss_values_shorthand_two_type_t* bottom_right = ((mycss_values_shorthand_two_type_t*) (value->three->value));
+        if (bottom_right != NULL)
+        {
+            if (bottom_right->one == NULL)
+            {
+                bottom_right->one = ((mycss_values_shorthand_two_type_t*) (value->one->value))->one;
+                bottom_right->type_one = ((mycss_values_shorthand_two_type_t*) (value->one->value))->type_one;
+            }
+            else if (bottom_right->two == NULL)
+            {
+                bottom_right->two = ((mycss_values_shorthand_two_type_t*) (value->one->value))->two;
+                bottom_right->type_two = ((mycss_values_shorthand_two_type_t*) (value->one->value))->type_two;
+            }
+        }
+
+        mycss_values_shorthand_two_type_t *bottom_left = ((mycss_values_shorthand_two_type_t*) (value->four->value));
+        if (bottom_left != NULL)
+        {
+            if (bottom_left->one == NULL)
+            {
+                bottom_left->one = ((mycss_values_shorthand_two_type_t*) (value->two->value))->one;
+                bottom_left->type_one = ((mycss_values_shorthand_two_type_t*) (value->two->value))->type_one;
+            }
+            else if (bottom_left->two == NULL)
+            {
+                bottom_left->two = ((mycss_values_shorthand_two_type_t*) (value->two->value))->two;
+                bottom_left->type_two = ((mycss_values_shorthand_two_type_t*) (value->two->value))->type_two;
+            }
+        }
+
         return true;
     }
     
@@ -934,13 +979,13 @@ bool mycss_property_parser_border_radius_two(mycss_entry_t* entry, mycss_token_t
     {
         if((value->four = mycss_property_parser_border_radius_shared(entry, token, &str, false))) {
             value->four->type = MyCSS_PROPERTY_TYPE_BORDER_BOTTOM_LEFT_RADIUS;
-            return mycss_property_parser_destroy_string(&str, mycss_property_shared_switch_to_find_important(entry));
+            return mycss_property_parser_destroy_string(&str, true);
         }
     }
     else if(((mycss_values_shorthand_two_type_t*)(value->four->value))->two == NULL)
     {
         if(mycss_property_parser_border_radius_two_shared(entry, token, value->four->value, &str))
-            return mycss_property_parser_destroy_string(&str, mycss_property_shared_switch_to_find_important(entry));
+            return mycss_property_parser_destroy_string(&str, true);
     }
     
     return mycss_property_parser_destroy_string(&str, mycss_property_shared_switch_to_parse_error(entry));


### PR DESCRIPTION
When parsing border radius with horizontal/vertical values, append missing values accordingly to the top-right, bottom-right and bottom-left when missing: For instance: border-radius:1px/2px 3px; should be parsed as border-radius: 1px 1px 1px 1px/ 2px 3px 2px 3px;